### PR TITLE
Wrap the tee.h in the library and revert a commit

### DIFF
--- a/libqcomtee/CMakeLists.txt
+++ b/libqcomtee/CMakeLists.txt
@@ -24,7 +24,7 @@ set(SRC
         src/objects/credentials_obj.c
 )
 
-add_library(${PROJECT_NAME} ${SRC})
+add_library(qcomtee ${SRC})
 
 # ''Library pkg-config file and version''.
 
@@ -33,25 +33,25 @@ set(libqcomteetgt qcomtee)
 
 configure_file(qcomtee.pc.in qcomtee.pc @ONLY)
 
-set_target_properties(${PROJECT_NAME} PROPERTIES
+set_target_properties(qcomtee PROPERTIES
 	VERSION ${PROJECT_VERSION}
 	SOVERSION ${PROJECT_VERSION_MAJOR}
 )
 
 # ''Headers and dependencies''.
 
-target_include_directories(${PROJECT_NAME}
+target_include_directories(qcomtee
 	PUBLIC include
 	PRIVATE src
 )
 
-target_link_libraries(${PROJECT_NAME}
+target_link_libraries(qcomtee
 	PRIVATE ${QCBOR_LIBRARIES}
 )
 
 # ''Install targets''.
 
-install(TARGETS ${PROJECT_NAME}
+install(TARGETS qcomtee
 	LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 	ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
 )

--- a/libqcomtee/include/qcomtee_object.h
+++ b/libqcomtee/include/qcomtee_object.h
@@ -4,8 +4,8 @@
 #ifndef _QCOMTEE_OBJECT_H
 #define _QCOMTEE_OBJECT_H
 
+#include <stdarg.h>
 #include <stdatomic.h>
-#include <linux/tee.h>
 #include "qcomtee_errno.h"
 
 #include <stdio.h>
@@ -319,7 +319,6 @@ int qcomtee_object_invoke(struct qcomtee_object *object, qcomtee_op_t op,
  * @return On success, 0; Otherwise, returns -1.
  */
 int qcomtee_object_process_one(struct qcomtee_object *root,
-			       int (*tee_call)(int, int,
-					       struct tee_ioctl_buf_data *));
+			       int (*tee_call)(int, int, ...));
 
 #endif // _QCOMTEE_OBJECT_H

--- a/libqcomtee/src/qcomtee_object.c
+++ b/libqcomtee/src/qcomtee_object.c
@@ -9,6 +9,7 @@
 #include <unistd.h>
 #include <sys/ioctl.h>
 
+#include <linux/tee.h>
 #include <qcomtee_object.h>
 
 /**
@@ -834,8 +835,7 @@ static int qcomtee_object_dispatch_request(struct qcomtee_object *object,
 }
 
 int qcomtee_object_process_one(struct qcomtee_object *root,
-			       int (*tee_call)(int, int,
-					       struct tee_ioctl_buf_data *))
+			       int (*tee_call)(int, int, ...))
 {
 	struct tee_ioctl_buf_data buf_data;
 	struct tee_ioctl_param *tee_params;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,6 +27,6 @@ target_include_directories(${PROJECT_NAME}
 )
 
 target_link_libraries(${PROJECT_NAME}
-	PRIVATE libqcomtee
+	PRIVATE qcomtee
 	PRIVATE ${CMAKE_THREAD_LIBS_INIT}
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,7 +24,6 @@ add_executable(${PROJECT_NAME} ${SRC})
 
 target_include_directories(${PROJECT_NAME}
 	PRIVATE src
-	PRIVATE ../libqcomtee/src
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/tests/common.c
+++ b/tests/common.c
@@ -1,8 +1,10 @@
 // Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <pthread.h>
 #include <stdarg.h>
 #include <sys/ioctl.h>
+
 #include "tests_private.h"
 
 struct supplicant {
@@ -11,12 +13,17 @@ struct supplicant {
 };
 
 /* op is TEE_IOC_SUPPL_RECV or TEE_IOC_SUPPL_SEND. */
-static int tee_call(int fd, int op, struct tee_ioctl_buf_data *buf_data)
+static int tee_call(int fd, int op, ...)
 {
+	va_list ap;
 	int ret;
 
+	va_start(ap, op);
+	void *arg = va_arg(ap, void *);
+	va_end(ap);
+
 	pthread_setcanceltype(PTHREAD_CANCEL_ASYNCHRONOUS, NULL);
-	ret = ioctl(fd, op, buf_data);
+	ret = ioctl(fd, op, arg);
 	pthread_setcanceltype(PTHREAD_CANCEL_DEFERRED, NULL);
 	if (ret)
 		PRINT("ioctl: %s, %d\n", strerror(errno), op);

--- a/tests/tests_private.h
+++ b/tests/tests_private.h
@@ -5,7 +5,6 @@
 #define _TESTS_PRIVATE_H
 
 #include <string.h>
-#include <pthread.h>
 #include <stdlib.h>
 
 #include <qcomtee_object_types.h>


### PR DESCRIPTION
It should be possible for user of this library to use tee without accessing to the linux/tee.h.
I mistakenly posted a commit which should not have been there, revert it.