### PR TITLE
Introduce tee_call_t and cleanup

### DIFF
--- a/libqcomtee/include/qcomtee_object.h
+++ b/libqcomtee/include/qcomtee_object.h
@@ -282,6 +282,12 @@ int qcomtee_object_cb_init(struct qcomtee_object *object,
 			   struct qcomtee_object_ops *ops,
 			   struct qcomtee_object *root);
 
+#ifdef __GLIBC__
+typedef int (*tee_call_t)(int, unsigned long, ...);
+#else
+typedef int (*tee_call_t)(int, int, ...);
+#endif
+
 /**
  * @brief Invoke an Object.
  *
@@ -293,11 +299,12 @@ int qcomtee_object_cb_init(struct qcomtee_object *object,
  * @param params Input parameter array to the requested operation.
  * @param num_params Number of parameter in the input array.
  * @param result Result of operation.
+ * @param tee_call Submit request to kernel driver.
  * @return On success, 0; Otherwise, returns -1.
  */
 int qcomtee_object_invoke(struct qcomtee_object *object, qcomtee_op_t op,
 			  struct qcomtee_param *params, int num_params,
-			  qcomtee_result_t *result);
+			  qcomtee_result_t *result, tee_call_t tee_call);
 
 /**
  * @brief Process single request.
@@ -319,6 +326,6 @@ int qcomtee_object_invoke(struct qcomtee_object *object, qcomtee_op_t op,
  * @return On success, 0; Otherwise, returns -1.
  */
 int qcomtee_object_process_one(struct qcomtee_object *root,
-			       int (*tee_call)(int, int, ...));
+			       tee_call_t tee_call);
 
 #endif // _QCOMTEE_OBJECT_H

--- a/libqcomtee/src/qcomtee_object.c
+++ b/libqcomtee/src/qcomtee_object.c
@@ -923,8 +923,8 @@ int qcomtee_object_process_one(struct qcomtee_object *root, tee_call_t tee_call)
 
 	/* DONE! */
 
-	if (object != QCOMTEE_OBJECT_NULL && object->ops->error) {
-		if (err == WITH_RESPONSE_ERR || err == WITH_RESPONSE)
+	if (err == WITH_RESPONSE_ERR || err == WITH_RESPONSE) {
+		if (object->ops->error)
 			object->ops->error(object, err);
 	}
 

--- a/tests/diagnostics.c
+++ b/tests/diagnostics.c
@@ -43,9 +43,9 @@ void test_print_diagnostics_info(void)
 	params[0].attr = QCOMTEE_UBUF_OUTPUT;
 	params[0].ubuf = UBUF_INIT(&heap_info);
 	/* 0 is IDiagnostics_OP_queryHeapInfo. */
-	if (qcomtee_object_invoke(service_object, 0, params, 1, &result) ||
+	if (test_object_invoke(service_object, 0, params, 1, &result) ||
 	    (result != QCOMTEE_OK)) {
-		PRINT("qcomtee_object_invoke.\n");
+		PRINT("test_object_invoke.\n");
 		goto dec_service_object;
 	}
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -11,7 +11,8 @@ static void usage(char *name)
 	       "\t-d - Run the TZ diagnostics test that prints basic info on TZ heaps.\n"
 	       "\t-l - Load the test TA and send command.\n"
 	       "\t\t%s -l <path to TA binary> <command>\n"
-	       "\t-h - Print this help message and exit\n\n", name);
+	       "\t-h - Print this help message and exit\n\n",
+	       name);
 }
 
 int main(int argc, char *argv[])

--- a/tests/ta_load.c
+++ b/tests/ta_load.c
@@ -26,7 +26,7 @@ static int test_ta_cmd_0(struct qcomtee_object *ta)
 	params[1].attr = QCOMTEE_UBUF_OUTPUT;
 	params[1].ubuf = UBUF_INIT(&sum);
 	/* 0 is ISMCIExample_OP_add. */
-	if (qcomtee_object_invoke(ta, 0, params, 2, &result) ||
+	if (test_object_invoke(ta, 0, params, 2, &result) ||
 	    (result != QCOMTEE_OK))
 		return -1;
 
@@ -63,9 +63,9 @@ static struct ta test_load_ta(struct qcomtee_object *service_object,
 	params[0].ubuf.size = size;
 	params[1].attr = QCOMTEE_OBJREF_OUTPUT;
 	/* 0 is IAppLoader_OP_loadFromBuffer. */
-	if (qcomtee_object_invoke(service_object, 0, params, 2, &result) ||
+	if (test_object_invoke(service_object, 0, params, 2, &result) ||
 	    (result != QCOMTEE_OK)) {
-		PRINT("qcomtee_object_invoke.\n");
+		PRINT("test_object_invoke.\n");
 		goto failed_out;
 	}
 
@@ -74,9 +74,9 @@ static struct ta test_load_ta(struct qcomtee_object *service_object,
 	/* INIT parameters and invoke object: */
 	params[0].attr = QCOMTEE_OBJREF_OUTPUT;
 	/* 2 is IAppController_OP_getAppObject . */
-	if (qcomtee_object_invoke(ta.ta_controller, 2, params, 1, &result) ||
+	if (test_object_invoke(ta.ta_controller, 2, params, 1, &result) ||
 	    (result != QCOMTEE_OK)) {
-		PRINT("qcomtee_object_invoke.\n");
+		PRINT("test_object_invoke.\n");
 		goto failed_out;
 	}
 

--- a/tests/tests_private.h
+++ b/tests/tests_private.h
@@ -12,6 +12,14 @@
 /* Driver's file.*/
 #define DEV_TEE "/dev/tee0"
 
+#ifdef __GLIBC__
+int tee_call(int fd, unsigned long op, ...);
+#else
+int tee_call(int fd, int op, ...);
+#endif
+
+#define test_object_invoke(...) qcomtee_object_invoke(__VA_ARGS__, tee_call)
+
 /**
  * @brief Get a root object.
  * @return On success, returns the object;


### PR DESCRIPTION
- Use typedef so the caller can pass ioctl directly to the function without the need to redefine the ioctl wrapper.
- Update test for the change.
- Some random cleanup.