### PR TITLE
Mem object

### DIFF
--- a/libqcomtee/CMakeLists.txt
+++ b/libqcomtee/CMakeLists.txt
@@ -20,8 +20,9 @@ include_directories(${QCBOR_INCLUDE_DIRS})
 # ''Source files''.
 
 set(SRC
-        src/qcomtee_object.c
-        src/objects/credentials_obj.c
+	src/qcomtee_object.c
+	src/objects/credentials_obj.c
+	src/objects/mem_obj.c
 )
 
 add_library(qcomtee ${SRC})

--- a/libqcomtee/include/qcomtee_object.h
+++ b/libqcomtee/include/qcomtee_object.h
@@ -142,6 +142,7 @@ typedef enum {
 	QCOMTEE_OBJECT_TYPE_TEE, /**< It is an object hosted in QTEE. */
 	QCOMTEE_OBJECT_TYPE_ROOT, /**< It is a root object. */
 	QCOMTEE_OBJECT_TYPE_CB, /**< It is a callback object. */
+	QCOMTEE_OBJECT_TYPE_MEMORY, /**< It is a memory object. */
 } qcomtee_object_type_t;
 
 /**

--- a/libqcomtee/include/qcomtee_object.h
+++ b/libqcomtee/include/qcomtee_object.h
@@ -56,7 +56,7 @@ typedef uint32_t qcomtee_op_t;
  * @brief Release object.
  * 
  */
-#define QCOMTEE_OBJREF_OP_RELEASE ((qcomtee_op_t)(65536))
+#define QCOMTEE_OBJREF_OP_RELEASE ((qcomtee_op_t)(65535))
 
 /** @} */ // end of ObjRefOperations
 

--- a/libqcomtee/include/qcomtee_object.h
+++ b/libqcomtee/include/qcomtee_object.h
@@ -24,10 +24,22 @@ typedef uint32_t qcomtee_op_t;
  */
 
 /**
+  * @def QCOMTEE_OBJREF_TEE
+  * @brief It indicates that the object is hosted in QTEE.
+  */
+#define QCOMTEE_OBJREF_TEE (1 << 0)
+
+/**
  * @def QCOMTEE_OBJREF_USER
  * @brief It indicates that the object is hosted in userspace.
  */
-#define QCOMTEE_OBJREF_USER (1 << 0)
+#define QCOMTEE_OBJREF_USER (1 << 1)
+
+/**
+ * @def QCOMTEE_OBJREF_MEM
+ * @brief It indicates that the object is a memory object.
+ */
+#define QCOMTEE_OBJREF_MEM (1 << 2)
 
 /** @} */ // end of ObjRefFlags
 

--- a/libqcomtee/include/qcomtee_object_types.h
+++ b/libqcomtee/include/qcomtee_object_types.h
@@ -17,4 +17,58 @@ qcomtee_result_t
 qcomtee_object_credentials_init(struct qcomtee_object *root,
 				struct qcomtee_object **object);
 
+/* Select qcomtee_memory_object_alloc vs. qcomtee_memory_object_register. */
+#define qcomtee_memory_object_tee_api_select(a, b, c, d, fun, ...) fun
+
+/**
+ * @brief Allocate a memory object.
+ *
+ * Memory object is owned by the caller and should be released using
+ * @ref qcomtee_memory_object_release.
+ *
+ * If sent to QTEE, a copy of the object is made and the owner keep their copy.
+ * In most usecases, the object owner needs to share memory with QTEE rather
+ * to donating it.
+ *
+ * For instance, if the memory object sent to QTEE in two different invocations,
+ * their would be three copies of the object:
+ *   - The owner copy.
+ *   - The two copies sent to QTEE in the invocations.
+ * Owner should release their copy using @ref qcomtee_memory_object_release.
+ * QTEE will release its two copies.
+ *
+ * If the owner wants to donate the memory they can release their copy
+ * @ref qcomtee_memory_object_release after the invocation to send the object.
+ *
+ * QTEE can only reference the memory objects that user owns. If the owner
+ * releases the object (so they hold no copy), they can not receive it
+ * back from QTEE.
+ *
+ *   - If the owner donates a memory object to QTEE, they can not receive
+ *     it from QTEE as @ref QCOMTEE_OBJREF_OUTPUT.
+ *   - If the owner shared a memory object to QTEE, they can receive it
+ *     from QTEE (a copy of the object is made and should be release
+ *     separately using @ref qcomtee_memory_object_release by the receiver).
+ *
+ * At any time, the owner can call @ref qcomtee_object_refs_inc to create a
+ * copy of the object. This copy should be released using
+ * @ref qcomtee_memory_object_release.
+ *
+ * @param size Size of the memory object.
+ * @param root The root object to which this object belongs.
+ * @param object Memory object.
+ * @return On success, returns 0; Otherwise, returns -1.
+ */
+int qcomtee_memory_object_alloc(size_t size, struct qcomtee_object *root,
+				struct qcomtee_object **object);
+
+void *qcomtee_memory_object_addr(struct qcomtee_object *object);
+size_t qcomtee_memory_object_size(struct qcomtee_object *object);
+
+/**
+ * @brief Release a memory object.
+ * @param object The object being released.
+ */
+void qcomtee_memory_object_release(struct qcomtee_object *object);
+
 #endif // _QCOMTEE_OBJECT_TYPES_H

--- a/libqcomtee/include/qcomtee_object_types.h
+++ b/libqcomtee/include/qcomtee_object_types.h
@@ -8,13 +8,13 @@
 
 /**
  * @brief Get a credentials object.
- * @param root_object The root object to which this object belongs.
+ * @param root The root object to which this object belongs.
  * @param object Credentials object.
  * @return On success returns @ref QCOMTEE_OK;
  *         Otherwise @ref QCOMTEE_ERROR_MEM.
  */
 qcomtee_result_t
-qcomtee_object_credentials_init(struct qcomtee_object *root_object,
+qcomtee_object_credentials_init(struct qcomtee_object *root,
 				struct qcomtee_object **object);
 
 #endif // _QCOMTEE_OBJECT_TYPES_H

--- a/libqcomtee/src/objects/credentials_obj.c
+++ b/libqcomtee/src/objects/credentials_obj.c
@@ -140,7 +140,7 @@ static struct qcomtee_object_ops ops = {
 };
 
 qcomtee_result_t
-qcomtee_object_credentials_init(struct qcomtee_object *root_object,
+qcomtee_object_credentials_init(struct qcomtee_object *root,
 				struct qcomtee_object **object)
 {
 	struct qcomtee_credentials *qcomtee_cred;
@@ -149,7 +149,7 @@ qcomtee_object_credentials_init(struct qcomtee_object *root_object,
 	if (!qcomtee_cred)
 		return QCOMTEE_ERROR_MEM;
 
-	qcomtee_object_cb_init(&qcomtee_cred->object, &ops, root_object);
+	qcomtee_object_cb_init(&qcomtee_cred->object, &ops, root);
 	/* INIT the credentials buffer. */
 	if (credentials_init(&qcomtee_cred->ubuf)) {
 		free(qcomtee_cred);

--- a/libqcomtee/src/objects/mem_obj.c
+++ b/libqcomtee/src/objects/mem_obj.c
@@ -1,0 +1,134 @@
+// Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <linux/tee.h>
+#include <qcomtee_object_types.h>
+#include <qcomtee_object_private.h>
+
+/* Which TEE API was used to prepare the memory object: */
+enum qcomtee_memory_type {
+	QCOMTEE_MEMORY_TEE_ALLOC = 1,
+	QCOMTEE_MEMORY_TEE_REGISTER
+};
+
+/**
+ * @brief Structure representing a memory object in TEE diver.
+ *
+ * This structure encapsulates information about a memory object
+ * used in TEE driver.
+ */
+struct qcomtee_memory {
+	struct qcomtee_object object;
+	enum qcomtee_memory_type type;
+	int fd; /**< File descriptor for TEE driver shm. */
+	struct {
+		void *addr; /**< mmaped address. */
+		size_t size; /**< size of memory. */
+	} mem_info;
+};
+
+#define MEMORY(o) container_of((o), struct qcomtee_memory, object)
+
+static void qcomtee_memory_release(struct qcomtee_object *object)
+{
+	struct qcomtee_memory *qcomtee_mem = MEMORY(object);
+
+	if (qcomtee_mem->type == QCOMTEE_MEMORY_TEE_ALLOC)
+		munmap(qcomtee_mem->mem_info.addr, qcomtee_mem->mem_info.size);
+
+	/* Release TEE shm. */
+	if (qcomtee_mem->fd != -1)
+		close(qcomtee_mem->fd);
+
+	free(qcomtee_mem);
+}
+
+/**
+ * @brief Allocate and initialize an empty memory object.
+ *
+ * The object has no physical memory assigned to it.
+ *
+ * @return On success, returns @ref qcomtee_memory; Otherwise, NULL.
+ */
+static struct qcomtee_memory *qcomtee_memory_alloc(void)
+{
+	struct qcomtee_memory *qcomtee_mem;
+	static struct qcomtee_object_ops ops = {
+		.release = qcomtee_memory_release,
+	};
+
+	qcomtee_mem = calloc(1, sizeof(*qcomtee_mem));
+	if (qcomtee_mem) {
+		QCOMTEE_OBJECT_INIT(&qcomtee_mem->object,
+				    QCOMTEE_OBJECT_TYPE_MEMORY);
+		qcomtee_mem->object.ops = &ops;
+		/* TEE shm not assigned yet. */
+		qcomtee_mem->fd = -1;
+	}
+
+	return qcomtee_mem;
+}
+
+int qcomtee_memory_object_alloc(size_t size, struct qcomtee_object *root,
+				struct qcomtee_object **object)
+{
+	struct root_object *root_object = ROOT_OBJECT(root);
+	struct tee_ioctl_shm_alloc_data data;
+	struct qcomtee_memory *qcomtee_mem;
+	void *addr;
+	int fd;
+
+	qcomtee_mem = qcomtee_memory_alloc();
+	if (!qcomtee_mem)
+		return -1;
+
+	data.size = size;
+	data.flags = 0;
+	data.id = 0;
+	fd = root_object->tee_call(root_object->fd, TEE_IOC_SHM_ALLOC, &data);
+	if (fd < 0)
+		goto err_release;
+
+	/* Assign TEE shm. */
+	qcomtee_mem->object.tee_object_id = data.id;
+	qcomtee_mem->fd = fd;
+
+	addr = mmap(NULL, data.size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+	if (addr == MAP_FAILED)
+		goto err_release;
+
+	/* INIT the memory object. */
+	qcomtee_mem->mem_info.addr = addr;
+	qcomtee_mem->mem_info.size = data.size;
+	qcomtee_mem->type = QCOMTEE_MEMORY_TEE_ALLOC;
+	/* Keep a copy of root object; released in qcomtee_object_refs_dec. */
+	qcomtee_object_refs_inc(root);
+	qcomtee_mem->object.root = root;
+
+	*object = &qcomtee_mem->object;
+
+	return 0;
+
+err_release:
+	qcomtee_memory_object_release(&qcomtee_mem->object);
+
+	return -1;
+}
+
+void *qcomtee_memory_object_addr(struct qcomtee_object *object)
+{
+	return MEMORY(object)->mem_info.addr;
+}
+
+size_t qcomtee_memory_object_size(struct qcomtee_object *object)
+{
+	return MEMORY(object)->mem_info.size;
+}
+
+void qcomtee_memory_object_release(struct qcomtee_object *object)
+{
+	qcomtee_object_refs_dec(object);
+}

--- a/libqcomtee/src/qcomtee_object.c
+++ b/libqcomtee/src/qcomtee_object.c
@@ -205,8 +205,11 @@ struct qcomtee_object *qcomtee_object_root_init(const char *dev,
 	root_object->tee_call = tee_call;
 	/* Open the driver. */
 	root_object->fd = open(dev, O_RDWR);
-	if (root_object->fd < 0)
+	if (root_object->fd < 0) {
+		MSGE("%s: %s\n", __func__, strerror(errno));
+
 		goto failed_out;
+	}
 
 	/* INIT the namespace. */
 	root_object->ns.current_idx = 0;
@@ -232,7 +235,7 @@ static void qcomtee_object_tee_release(struct qcomtee_object *object)
 	if (qcomtee_object_invoke(object, QCOMTEE_OBJREF_OP_RELEASE, NULL, 0,
 				  &result) ||
 	    (result != QCOMTEE_OK))
-		MSGE("QTEE object release failed!\n");
+		MSGE("%s: QCOMTEE_OBJREF_OP_RELEASE failed.\n", __func__);
 
 	free(object);
 	/* qcomtee_object_refs_inc has been called in qcomtee_object_tee_init. */

--- a/libqcomtee/src/qcomtee_object.c
+++ b/libqcomtee/src/qcomtee_object.c
@@ -335,7 +335,7 @@ static int qcomtee_object_param_to_tee_param(struct tee_ioctl_param *tee_param,
 		break;
 	case QCOMTEE_OBJECT_TYPE_TEE:
 		tee_param->a = object->object_id;
-		tee_param->b = 0;
+		tee_param->b = QCOMTEE_OBJREF_TEE;
 
 		break;
 	case QCOMTEE_OBJECT_TYPE_CB:

--- a/libqcomtee/src/qcomtee_object.c
+++ b/libqcomtee/src/qcomtee_object.c
@@ -303,7 +303,8 @@ void qcomtee_object_refs_dec(struct qcomtee_object *object)
 			qcomtee_object_tee_release(object);
 
 			break;
-		case QCOMTEE_OBJECT_TYPE_CB: {
+		case QCOMTEE_OBJECT_TYPE_CB:
+		case QCOMTEE_OBJECT_TYPE_MEMORY: {
 			struct qcomtee_object *root = object->root;
 
 			/* It dequeues the object if it is already queued. */
@@ -335,13 +336,14 @@ static int qcomtee_object_param_to_tee_param(struct tee_ioctl_param *tee_param,
 {
 	/* It assumes param is object. */
 	struct qcomtee_object *object = param->object;
+	qcomtee_object_type_t object_type = qcomtee_object_typeof(object);
 
 	/* It expects caller to set tee_param attribute. */
 	if (tee_param->attr != TEE_IOCTL_PARAM_ATTR_TYPE_OBJREF_INPUT &&
 	    tee_param->attr != TEE_IOCTL_PARAM_ATTR_TYPE_OBJREF_OUTPUT)
 		return -1;
 
-	switch (qcomtee_object_typeof(object)) {
+	switch (object_type) {
 	case QCOMTEE_OBJECT_TYPE_NULL:
 		tee_param->a = TEE_OBJREF_NULL;
 		tee_param->b = 0;
@@ -353,6 +355,7 @@ static int qcomtee_object_param_to_tee_param(struct tee_ioctl_param *tee_param,
 
 		break;
 	case QCOMTEE_OBJECT_TYPE_CB:
+	case QCOMTEE_OBJECT_TYPE_MEMORY:
 		/* Only accept object that belong to the same namespace. */
 		if (object->root != root)
 			return -1;
@@ -366,7 +369,11 @@ static int qcomtee_object_param_to_tee_param(struct tee_ioctl_param *tee_param,
 			object->tee_object_id = object->object_id;
 
 		tee_param->a = object->tee_object_id;
-		tee_param->b = QCOMTEE_OBJREF_USER;
+
+		if (object_type == QCOMTEE_OBJECT_TYPE_CB)
+			tee_param->b = QCOMTEE_OBJREF_USER;
+		else /* QCOMTEE_OBJECT_TYPE_MEMORY. */
+			tee_param->b = QCOMTEE_OBJREF_MEM;
 
 		break;
 	default:
@@ -405,7 +412,11 @@ qcomtee_object_param_from_tee_param(struct qcomtee_param *param,
 		object = qcomtee_object_ns_find(tee_param->a,
 						QCOMTEE_OBJECT_TYPE_CB,
 						ROOT_OBJECT_NS(root));
-	} else {
+	} else if (tee_param->b == QCOMTEE_OBJREF_MEM) {
+		object = qcomtee_object_ns_find(tee_param->a,
+						QCOMTEE_OBJECT_TYPE_MEMORY,
+						ROOT_OBJECT_NS(root));
+	} else { /* QCOMTEE_OBJREF_TEE. */
 		object = qcomtee_object_tee_init(root, tee_param->a);
 	}
 

--- a/libqcomtee/src/qcomtee_object_private.h
+++ b/libqcomtee/src/qcomtee_object_private.h
@@ -1,0 +1,70 @@
+// Copyright (c) 2025, Qualcomm Innovation Center, Inc. All rights reserved.
+// SPDX-License-Identifier: BSD-3-Clause
+
+#ifndef _QCOMTEE_OBJECT_PRIVATE_H
+#define _QCOMTEE_OBJECT_PRIVATE_H
+
+#include <pthread.h>
+#include <string.h>
+#include <qcomtee_object.h>
+
+/**
+ * @def TABLE_SIZE
+ * @brief The number of objects that can be exported to QTEE in each root object.
+ */
+#define TABLE_SIZE 1024
+
+/**
+ * @brief Object namespace.
+ *
+ * Every time a root object is created, a new namespace is initiated.
+ * This guarantees that callback objects exported to QTEE using a root object
+ * can only be referenced by QTEE in the namespace maintained by the root
+ * object. For QTEE objects, the kernel driver guarantees that objects
+ * received using a root object are not visible to others.
+ */
+struct qcomtee_object_namespace {
+	int current_idx; /**< Index to start searching for free entry. */
+	struct qcomtee_object *entries[TABLE_SIZE]; /**< Callback object table. */
+	pthread_mutex_t lock; /**< lock to protect members of this struct. */
+};
+
+/**
+ * @brief Root object.
+ *
+ * Use @ref qcomtee_object_root_init to create a root object and a namespace.
+ */
+struct root_object {
+	struct qcomtee_object object;
+	struct qcomtee_object_namespace ns;
+	int fd; /**< Driver's fd. */
+	tee_call_t tee_call; /**< API to call to TEE driver (e.g. ioctl()). */
+	void (*release)(void *);
+	void *arg; /**< Argument passed to release. */
+};
+
+#define ROOT_OBJECT(ro) container_of((ro), struct root_object, object)
+#define ROOT_OBJECT_NS(ro) (&ROOT_OBJECT(ro)->ns)
+
+/**
+ * @def OBJECT_NS
+ * @brief Returns the namespace the object belongs to.
+ */
+#define OBJECT_NS(o) ROOT_OBJECT_NS((o)->root)
+
+/**
+ * @brief Initialize an object.
+ * @param object Object to initialize.
+ * @param object_type Type of the object.
+ */
+static inline void QCOMTEE_OBJECT_INIT(struct qcomtee_object *object,
+				       qcomtee_object_type_t object_type)
+{
+	memset(object, 0, sizeof(*object));
+
+	atomic_init(&object->refs, 1);
+	object->object_type = object_type;
+	object->root = QCOMTEE_OBJECT_NULL;
+}
+
+#endif // _QCOMTEE_OBJECT_PRIVATE_H

--- a/tests/diagnostics.c
+++ b/tests/diagnostics.c
@@ -43,9 +43,9 @@ void test_print_diagnostics_info(void)
 	params[0].attr = QCOMTEE_UBUF_OUTPUT;
 	params[0].ubuf = UBUF_INIT(&heap_info);
 	/* 0 is IDiagnostics_OP_queryHeapInfo. */
-	if (test_object_invoke(service_object, 0, params, 1, &result) ||
+	if (qcomtee_object_invoke(service_object, 0, params, 1, &result) ||
 	    (result != QCOMTEE_OK)) {
-		PRINT("test_object_invoke.\n");
+		PRINT("qcomtee_object_invoke.\n");
 		goto dec_service_object;
 	}
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -10,7 +10,7 @@ static void usage(char *name)
 	printf("OPTION are:\n"
 	       "\t-d - Run the TZ diagnostics test that prints basic info on TZ heaps.\n"
 	       "\t-l - Load the test TA and send command.\n"
-	       "\t\t%s -l <path to TA binary> <command>\n"
+	       "\t\t%s -l <path to TA binary> <buffer vs. memory object> <command>\n"
 	       "\t-h - Print this help message and exit\n\n",
 	       name);
 }
@@ -22,10 +22,10 @@ int main(int argc, char *argv[])
 		test_print_diagnostics_info();
 		break;
 	case 'l':
-		if (argc != 4)
+		if (argc != 5)
 			goto help;
 
-		test_load_sample_ta(argv[2], atoi(argv[3]));
+		test_load_sample_ta(argv[2], atoi(argv[3]), atoi(argv[4]));
 		break;
 help:
 	case 'h':

--- a/tests/ta_load.c
+++ b/tests/ta_load.c
@@ -4,6 +4,14 @@
 #include <time.h>
 #include "tests_private.h"
 
+struct ta {
+	struct qcomtee_object *ta_controller;
+	struct qcomtee_object *ta;
+};
+
+/* ROOT used in this test. */
+static struct qcomtee_object *root;
+
 static int test_ta_cmd_0(struct qcomtee_object *ta)
 {
 	struct qcomtee_param params[2];
@@ -39,23 +47,19 @@ static int test_ta_cmd_0(struct qcomtee_object *ta)
 	return -1;
 }
 
-struct ta {
-	struct qcomtee_object *ta_controller;
-	struct qcomtee_object *ta;
-};
-
-static struct ta test_load_ta(struct qcomtee_object *service_object,
-			      const char *pathname)
+static struct qcomtee_object *
+test_load_ta_buffer(struct qcomtee_object *service_object, const char *pathname)
 {
-	struct ta ta = { QCOMTEE_OBJECT_NULL, QCOMTEE_OBJECT_NULL };
 	struct qcomtee_param params[2];
 	qcomtee_result_t result;
-
 	char *buffer;
 	size_t size;
+	int ret;
+
 	/* Read the TA file. */
-	if (test_read_file2(pathname, TEST_TA, &buffer, &size))
-		return ta;
+	size = test_read_file2(pathname, TEST_TA, &buffer, 0);
+	if (!size)
+		return QCOMTEE_OBJECT_NULL;
 
 	/* INIT parameters and invoke object: */
 	params[0].attr = QCOMTEE_UBUF_INPUT;
@@ -63,13 +67,73 @@ static struct ta test_load_ta(struct qcomtee_object *service_object,
 	params[0].ubuf.size = size;
 	params[1].attr = QCOMTEE_OBJREF_OUTPUT;
 	/* 0 is IAppLoader_OP_loadFromBuffer. */
-	if (qcomtee_object_invoke(service_object, 0, params, 2, &result) ||
-	    (result != QCOMTEE_OK)) {
+	ret = qcomtee_object_invoke(service_object, 0, params, 2, &result);
+	/* Free buffer allocated in test_read_file2. */
+	free(buffer);
+
+	if (ret || (result != QCOMTEE_OK)) {
 		PRINT("qcomtee_object_invoke.\n");
-		goto failed_out;
+		return QCOMTEE_OBJECT_NULL;
 	}
 
-	ta.ta_controller = params[1].object;
+	return params[1].object;
+}
+
+static struct qcomtee_object *
+test_load_ta_region(struct qcomtee_object *service_object, const char *pathname)
+{
+	struct qcomtee_param params[2];
+	qcomtee_result_t result;
+	char *buffer;
+	size_t size;
+	int ret;
+
+	/* Prepare memory object. */
+	struct qcomtee_object *mo;
+
+	size = test_get_file_size_by_filename(pathname, TEST_TA);
+	if (!size)
+		return QCOMTEE_OBJECT_NULL;
+
+	if (qcomtee_memory_object_alloc(size, root, &mo))
+		return QCOMTEE_OBJECT_NULL;
+
+	buffer = qcomtee_memory_object_addr(mo);
+	/* Read the TA file. */
+	size = test_read_file2(pathname, TEST_TA, &buffer,
+			       qcomtee_memory_object_size(mo));
+	if (!size)
+		return QCOMTEE_OBJECT_NULL;
+
+	/* INIT parameters and invoke object: */
+	params[0].attr = QCOMTEE_OBJREF_INPUT;
+	params[0].object = mo;
+	params[1].attr = QCOMTEE_OBJREF_OUTPUT;
+	/* 1 is IAppLoader_OP_loadFromRegion. */
+	ret = qcomtee_object_invoke(service_object, 1, params, 2, &result);
+	/* The memory object donated to QTEE; release it. QTEE releases it's copy. */
+	qcomtee_memory_object_release(mo);
+
+	if (ret || (result != QCOMTEE_OK)) {
+		PRINT("qcomtee_object_invoke.\n");
+		return QCOMTEE_OBJECT_NULL;
+	}
+
+	return params[1].object;
+}
+
+static struct ta test_load_ta(struct qcomtee_object *service_object, int use_mo,
+			      const char *pathname)
+{
+	struct ta ta = { QCOMTEE_OBJECT_NULL, QCOMTEE_OBJECT_NULL };
+	struct qcomtee_param params[2];
+	qcomtee_result_t result;
+
+	ta.ta_controller =
+		use_mo ? test_load_ta_region(service_object, pathname) :
+			 test_load_ta_buffer(service_object, pathname);
+	if (ta.ta_controller == QCOMTEE_OBJECT_NULL)
+		return ta;
 
 	/* INIT parameters and invoke object: */
 	params[0].attr = QCOMTEE_OBJREF_OUTPUT;
@@ -77,21 +141,18 @@ static struct ta test_load_ta(struct qcomtee_object *service_object,
 	if (qcomtee_object_invoke(ta.ta_controller, 2, params, 1, &result) ||
 	    (result != QCOMTEE_OK)) {
 		PRINT("qcomtee_object_invoke.\n");
-		goto failed_out;
+		return ta;
 	}
 
 	ta.ta = params[0].object;
 
-failed_out:
-	free(buffer);
-
 	return ta;
 }
 
-void test_load_sample_ta(const char *pathname, int cmd)
+void test_load_sample_ta(const char *pathname, int use_mo, int cmd)
 {
 	struct ta test_ta;
-	struct qcomtee_object *root, *client_env_object, *service_object;
+	struct qcomtee_object *client_env_object, *service_object;
 
 	/* Get root + supplicant. */
 	root = test_get_root();
@@ -114,7 +175,7 @@ void test_load_sample_ta(const char *pathname, int cmd)
 	}
 
 	/* Load the TA. */
-	test_ta = test_load_ta(service_object, pathname);
+	test_ta = test_load_ta(service_object, use_mo, pathname);
 	if (test_ta.ta == QCOMTEE_OBJECT_NULL) {
 		PRINT("test_load_ta.\n");
 		goto dec_service_object;
@@ -131,6 +192,7 @@ void test_load_sample_ta(const char *pathname, int cmd)
 		break;
 	default:
 		PRINT("Unknown command (%d).\n", cmd);
+
 		goto dec_unload_ta;
 	}
 

--- a/tests/ta_load.c
+++ b/tests/ta_load.c
@@ -26,7 +26,7 @@ static int test_ta_cmd_0(struct qcomtee_object *ta)
 	params[1].attr = QCOMTEE_UBUF_OUTPUT;
 	params[1].ubuf = UBUF_INIT(&sum);
 	/* 0 is ISMCIExample_OP_add. */
-	if (test_object_invoke(ta, 0, params, 2, &result) ||
+	if (qcomtee_object_invoke(ta, 0, params, 2, &result) ||
 	    (result != QCOMTEE_OK))
 		return -1;
 
@@ -63,9 +63,9 @@ static struct ta test_load_ta(struct qcomtee_object *service_object,
 	params[0].ubuf.size = size;
 	params[1].attr = QCOMTEE_OBJREF_OUTPUT;
 	/* 0 is IAppLoader_OP_loadFromBuffer. */
-	if (test_object_invoke(service_object, 0, params, 2, &result) ||
+	if (qcomtee_object_invoke(service_object, 0, params, 2, &result) ||
 	    (result != QCOMTEE_OK)) {
-		PRINT("test_object_invoke.\n");
+		PRINT("qcomtee_object_invoke.\n");
 		goto failed_out;
 	}
 
@@ -74,9 +74,9 @@ static struct ta test_load_ta(struct qcomtee_object *service_object,
 	/* INIT parameters and invoke object: */
 	params[0].attr = QCOMTEE_OBJREF_OUTPUT;
 	/* 2 is IAppController_OP_getAppObject . */
-	if (test_object_invoke(ta.ta_controller, 2, params, 1, &result) ||
+	if (qcomtee_object_invoke(ta.ta_controller, 2, params, 1, &result) ||
 	    (result != QCOMTEE_OK)) {
-		PRINT("test_object_invoke.\n");
+		PRINT("qcomtee_object_invoke.\n");
 		goto failed_out;
 	}
 

--- a/tests/tests_private.h
+++ b/tests/tests_private.h
@@ -40,9 +40,10 @@ test_get_service_object(struct qcomtee_object *client_env_object, uint32_t uid);
 
 /* File stuff. */
 size_t test_get_file_size(FILE *file);
-int test_read_file(const char *filename, char **buffer, size_t *size);
-int test_read_file2(const char *pathname, const char *name, char **buffer,
-		    size_t *size);
+size_t test_read_file(const char *filename, char **buffer, size_t size);
+size_t test_get_file_size_by_filename(const char *pathname, const char *name);
+size_t test_read_file2(const char *pathname, const char *name, char **buffer,
+		       size_t size);
 
 #define PRINT(fmt, ...) \
 	printf("[%s][%d] " fmt, __func__, __LINE__, ##__VA_ARGS__)
@@ -56,6 +57,6 @@ void test_print_diagnostics_info(void);
 /* ta_load.c. */
 #define TEST_TA "smcinvoke_skeleton_ta64.mbn"
 
-void test_load_sample_ta(const char *pathname, int cmd);
+void test_load_sample_ta(const char *pathname, int use_mo, int cmd);
 
 #endif // _TESTS_PRIVATE_H

--- a/tests/tests_private.h
+++ b/tests/tests_private.h
@@ -12,14 +12,6 @@
 /* Driver's file.*/
 #define DEV_TEE "/dev/tee0"
 
-#ifdef __GLIBC__
-int tee_call(int fd, unsigned long op, ...);
-#else
-int tee_call(int fd, int op, ...);
-#endif
-
-#define test_object_invoke(...) qcomtee_object_invoke(__VA_ARGS__, tee_call)
-
 /**
  * @brief Get a root object.
  * @return On success, returns the object;


### PR DESCRIPTION
All commit to prepare for memory object, including:
  - extending ns code to handle typed objects including changes to synchronization as ns table users extended to local users.
  - differentiate between local id and id seen by QTEE.
  - clean up and bugfixes.