### PR TITLE
quic-teec: update the find way of the QCBOR

### DIFF
--- a/libqcomtee/cmake/FindQCBOR.cmake
+++ b/libqcomtee/cmake/FindQCBOR.cmake
@@ -1,13 +1,13 @@
 find_path(QCBOR_INCLUDE_DIR
         NAMES qcbor/qcbor.h
         HINTS ${QCBOR_DIR_HINT}
-        PATH_SUFFIXES include
+        PATH_SUFFIXES inc
 )
 
 find_library(QCBOR_LIBRARY
         NAMES qcbor
         HINTS ${QCBOR_DIR_HINT}
-        PATH_SUFFIXES lib
+        PATH_SUFFIXES build
 )
 
 if(QCBOR_INCLUDE_DIR AND QCBOR_LIBRARY)


### PR DESCRIPTION
Fix the compilation issue that cannot find the libqcbor.a. The root cause is that the QCBOR include path has changed.