### PR TITLE
libqcomtee: Fix minor compilation issue for aarch64-gcc-9 toolchain.

### DIFF
--- a/libqcomtee/src/qcomtee_object.c
+++ b/libqcomtee/src/qcomtee_object.c
@@ -320,6 +320,7 @@ void qcomtee_object_refs_dec(struct qcomtee_object *object)
 		}
 		default:
 			/* NOTHING TO DO HERE. */
+			break;
 		}
 	}
 }


### PR DESCRIPTION
Fixed minor compilation issue with gcc 9 for missing 'break' statement in switch default case.