### PR TITLE
libqcomtee: fix compilation issue for meta-qcom

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.15)
 project(qcom-tee C)
 
 option(BUILD_UNITTEST "Build unittest" FALSE)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-project(unittest C)
+project(qcomteetest C)
 
 # ''Packages''.
 


### PR DESCRIPTION
1. Update Cmake version from version 3.4 to 3.15.
2. Rename the test case in a more specific way.