### PR TITLE
Fix a casting error during compiling qcomtee library

### DIFF
--- a/libqcomtee/src/qcomtee_object.c
+++ b/libqcomtee/src/qcomtee_object.c
@@ -571,7 +571,7 @@ static int qcomtee_object_cb_marshal_in(struct qcomtee_param *params,
 		switch (tee_params[i].attr) {
 		case TEE_IOCTL_PARAM_ATTR_TYPE_UBUF_INPUT:
 		case TEE_IOCTL_PARAM_ATTR_TYPE_UBUF_OUTPUT:
-			params[i].ubuf.addr = (void *)tee_params[i].a;
+			params[i].ubuf.addr = (void *)(uintptr_t)(tee_params[i].a);
 			params[i].ubuf.size = (size_t)tee_params[i].b;
 			params[i].attr =
 				(tee_params[i].attr ==


### PR DESCRIPTION
Encountered int-to-pointer-cast error when compiles the qcomtee library due to casting error.
Resolve the compilation error by ensuring the integer-to-pointer conversision is safe for all architectures.