### PR TITLE
Enable libcbor fallback when QCBOR is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ In order to build the _qcomtee_ library, you require QCBOR. It is not available 
 
 Use `-DQCBOR_DIR_HINT=/path/to/installed/dir` to specify the QCBOR dependency.
 
+However, if QCBOR is not present, _qcomtee_ library fallbacks to using libcbor [libcbor](https://github.com/PJK/libcbor).
+
+Libcbor can be installed on Ubuntu/Debian using:
+```
+sudo apt-get install libcbor-dev
+```
 
 ## Unittest
 List of available tests are [here](tests/README.md)

--- a/libqcomtee/CMakeLists.txt
+++ b/libqcomtee/CMakeLists.txt
@@ -11,8 +11,11 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(QCBOR_DIR_HINT "" CACHE PATH "Hint path for QCBOR directory")
 
 find_package(QCBOR REQUIRED)
-if(NOT QCBOR_FOUND)
-	message(FATAL_ERROR "QCBOR not found")
+if(QCBOR_FOUND)
+	add_compile_definitions(${PROJECT_NAME}
+		PRIVATE -DUSE_QCBOR)
+else()
+	message(WARNING "QCBOR not found, falling back to libcbor")
 endif()
 
 include_directories(${QCBOR_INCLUDE_DIRS})
@@ -46,9 +49,11 @@ target_include_directories(qcomtee
 	PRIVATE src
 )
 
-target_link_libraries(qcomtee
-	PRIVATE ${QCBOR_LIBRARIES}
-)
+if(QCBOR_FOUND)
+	target_link_libraries(qcomtee PRIVATE ${QCBOR_LIBRARIES})
+else()
+	target_link_libraries(qcomtee PRIVATE cbor)
+endif()
 
 # ''Install targets''.
 

--- a/libqcomtee/src/objects/credentials_obj.c
+++ b/libqcomtee/src/objects/credentials_obj.c
@@ -4,8 +4,13 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <sys/time.h>
-#include <qcbor/qcbor.h>
 #include <qcomtee_object_types.h>
+#ifdef USE_QCBOR
+#include <qcbor/qcbor.h>
+#else
+#include <cbor.h>
+#include <string.h>
+#endif
 
 #define IIO_OP_GET_LENGTH 0
 #define IIO_OP_READ_AT_OFFSET 1
@@ -29,6 +34,7 @@ enum {
 };
 
 #define CREDENTIALS_BUF_SIZE_INC 4096
+#ifdef USE_QCBOR
 static int realloc_useful_buf(UsefulBuf *buf)
 {
 	void *ptr;
@@ -72,6 +78,59 @@ static int credentials_init(struct qcomtee_ubuf *ubuf)
 
 	return 0;
 }
+#else
+static int credentials_init(struct qcomtee_ubuf *ubuf)
+{
+	cbor_mutable_data buffer = NULL;
+	cbor_item_t *creds_map = NULL;
+	struct cbor_pair map_pair;
+	size_t buffer_size = CREDENTIALS_BUF_SIZE_INC;
+
+	buffer = (unsigned char *)calloc(buffer_size, sizeof(unsigned char));
+	if (buffer == NULL)
+		return -1;
+
+	creds_map = cbor_new_definite_map(2);
+	if (creds_map == NULL)
+		goto map_init_fail;
+
+	map_pair.key = cbor_build_uint8(attr_uid);
+	map_pair.value = cbor_build_uint32((uint32_t)getuid());
+	if (!cbor_map_add(creds_map, map_pair))
+		goto map_add_fail;
+
+	map_pair.key = cbor_build_uint8(attr_system_time);
+	map_pair.value = cbor_build_uint64((uint64_t)get_time_in_ms());
+	if (!cbor_map_add(creds_map, map_pair))
+		goto map_add_fail;
+
+	/*
+	 * On failure in serialization we jump to map_serialize_fail
+	 * because cbor_decref() recursively frees all items already
+	 * added to the map. However, if cbor_map_add() fails, we
+	 * must manually decref the current key/value as ownership
+	 * is not transferred.
+	 */
+	buffer_size = cbor_serialize_map(creds_map, buffer, buffer_size);
+	if (buffer_size == 0)
+		goto map_serialize_fail;
+
+	ubuf->addr = (void *)buffer;
+	ubuf->size = buffer_size;
+
+	cbor_decref(&creds_map);
+	return 0;
+
+map_add_fail:
+	cbor_decref(&map_pair.key);
+	cbor_decref(&map_pair.value);
+map_serialize_fail:
+	cbor_decref(&creds_map);
+map_init_fail:
+	free(buffer);
+	return -1;
+}
+#endif
 
 /* CREDENTIAL callback object. */
 struct qcomtee_credentials {


### PR DESCRIPTION
qcomtee currently relies on QCBOR as the primary CBOR encoding library.
However, QCBOR is not available in several Linux distributions, which makes building, packaging, and deploying qcomtee difficult on those platforms.

Introduce a fallback implementation based on libcbor when QCBOR is not present. Libcbor is a widely available, standards‑compliant CBOR library implementing RFC 8949 (formerly RFC 7049) and RFC 8742, and is packaged by most major distributions including Debian/Ubuntu and Fedora/Red Hat.

Compared to QCBOR, libcbor is more feature‑rich which implements the full-blown RFC. However, it is less opinionated for embedded use‑cases. As a result, it places more responsibility on the caller for memory management and for ensuring canonical CBOR encoding.

The fallback implementation includes the necessary handling to maintain correctness and interoperability within qcomtee.
This change improves portability and lowers the barrier to adoption of qcomtee across a broader set of environments without removing or changing existing CBOR support.

Additionally, while secure firmware heavily relies on QCBOR, this change ensures interoperability across different CBOR implementations that conform to the CBOR standard.

Signed-off-by: Abhinaba Rakshit <abhinaba.rakshit@oss.qualcomm.com>