### PR TITLE
quic-teec: Document libcbor setup for cross-compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ However, if QCBOR is not present, _qcomtee_ library fallbacks to using libcbor [
 
 Libcbor can be installed on Ubuntu/Debian using:
 ```
-sudo apt-get install libcbor-dev
+sudo dpkg --add-architecture arm64
+sudo apt-get update
+sudo apt-get install libcbor-dev:arm64
 ```
 
 ## Unittest


### PR DESCRIPTION
The README currently describes assuming an x86 host build environment. Update it to also include the steps required to install libcbor when building quic-teec with cross-compilation.