### PR TITLE
tests: Fix file size logging format specifiers

### DIFF
--- a/tests/common.c
+++ b/tests/common.c
@@ -241,7 +241,7 @@ size_t test_read_file(const char *filename, char **buffer, size_t size)
 	if (size > 0) {
 		/* User provided the buffer; make sure it is large enough. */
 		if (size < file_size) {
-			MSG_ERROR("Buffer is small (required %lu)\n", file_size);
+			MSG_ERROR("Buffer is small (required %u)\n", file_size);
 			file_size = 0; /* Unable to read. */
 
 			goto out;
@@ -259,7 +259,7 @@ size_t test_read_file(const char *filename, char **buffer, size_t size)
 		}
 	}
 
-	MSG_INFO("Reading %s, %lu Bytes.\n", filename, file_size);
+	MSG_INFO("Reading %s, %u Bytes.\n", filename, file_size);
 
 	if (fread(file_buf, 1, file_size, file) != file_size) {
 		MSG_ERROR("%s\n", feof(file) ? "EOF" : strerror(errno));


### PR DESCRIPTION
The test_read_file() helper logs file size values using printf-style format strings. Update the MSG_ERROR() and MSG_INFO() calls to match the type of the file size argument and avoid compiler format warnings.

This keeps the test logging clean and prevents build failures when warnings are treated as errors.